### PR TITLE
Fix close signals crashing the console after Connect-DatpGraph is ran

### DIFF
--- a/src/mdatp-pwsh/powershell-cmdlets/core/ConnectDatpGraph.cs
+++ b/src/mdatp-pwsh/powershell-cmdlets/core/ConnectDatpGraph.cs
@@ -71,16 +71,18 @@ namespace MdatpPwsh.Cmdlets
                 };
 
             AuthenticationResult result = null;
+            ConsoleCancelEventHandler cancelEventHandler = new ConsoleCancelEventHandler(cancelHandler);
 
             try
             {
-                Console.CancelKeyPress += new ConsoleCancelEventHandler(cancelHandler);
+                Console.CancelKeyPress += cancelEventHandler;
                 CancellationToken token = cancellationTokenSource.Token;
 
                 result = TokenFlow.GetDeviceCode(scopes, token).GetAwaiter().GetResult();
             }
             catch (TaskCanceledException e)
             {
+                Console.CancelKeyPress -= cancelEventHandler;
                 cancellationTokenSource.Dispose();
 
                 ErrorRecord psErrorRecordObj = new ErrorRecord(
@@ -94,6 +96,7 @@ namespace MdatpPwsh.Cmdlets
             }
             finally
             {
+                Console.CancelKeyPress -= cancelEventHandler;
                 cancellationTokenSource.Dispose();
             }
 


### PR DESCRIPTION
Resolves #19

- The CancelEventHandler for when the cancel key is pressed is removed
  when either an exception is thrown or when the task gracefully exits.